### PR TITLE
Login via OpenID Connect

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+POSTGRES_HOST="localhost"
+POSTGRES_USER="timetable"
+POSTGRES_PASS="timetable"
+OP_ISSUER="https://sso.mikamai.com/auth/realms/mikamai"
+OP_CLIENT_ID="timetable-dev"
+OP_SECRET_KEY="b5beedbc-ff00-4d1e-a7dc-34451c29c224"

--- a/.env
+++ b/.env
@@ -1,6 +1,0 @@
-POSTGRES_HOST="localhost"
-POSTGRES_USER="timetable"
-POSTGRES_PASS="timetable"
-OP_ISSUER="https://sso.mikamai.com/auth/realms/mikamai"
-OP_CLIENT_ID="timetable-dev"
-OP_SECRET_KEY="b5beedbc-ff00-4d1e-a7dc-34451c29c224"

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ public/exports
 /coverage
 cookbook/*.retry
 .ruby-version
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'scenic'
 gem 'sidekiq', '~> 5.0'
 gem 'sidekiq-scheduler'
 gem 'webpacker'
+gem 'omniauth_openid_connect'
 
 # Uploads
 gem 'carrierwave'
@@ -85,3 +86,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+gem "annotate", "~> 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,11 +51,17 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    aes_key_wrap (1.0.1)
+    annotate (2.7.4)
+      activerecord (>= 3.2, < 6.0)
+      rake (>= 10.4, < 13.0)
     arel (8.0.0)
     ast (2.3.0)
+    attr_required (1.0.1)
     autoprefixer-rails (8.6.5)
       execjs
     bcrypt (3.1.11)
+    bindata (2.4.4)
     bindex (0.5.0)
     bootstrap (4.0.0.beta2.1)
       autoprefixer-rails (>= 6.0.3)
@@ -133,6 +139,8 @@ GEM
       activerecord (>= 4.0.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    hashie (3.6.0)
+    httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ipaddress (0.8.3)
@@ -144,6 +152,10 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
+    json-jwt (1.10.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -181,6 +193,23 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     oj (3.3.9)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
+      rack (>= 1.6.2, < 3)
+    omniauth_openid_connect (0.2.4)
+      addressable (~> 2.5)
+      omniauth (~> 1.3)
+      openid_connect (~> 1.1)
+    openid_connect (1.1.6)
+      activemodel
+      attr_required (>= 1.0.0)
+      json-jwt (>= 1.5.0)
+      rack-oauth2 (>= 1.6.1)
+      swd (>= 1.0.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (>= 1.0.1)
     orm_adapter (0.5.0)
     parallel (1.12.0)
     paranoia (2.4.1)
@@ -200,6 +229,12 @@ GEM
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.4)
+    rack-oauth2 (1.9.3)
+      activesupport
+      attr_required
+      httpclient
+      json-jwt (>= 1.9.0)
+      rack
     rack-protection (2.0.0)
       rack
     rack-proxy (0.6.4)
@@ -334,6 +369,10 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    swd (1.1.2)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.4)
     temple (0.8.0)
     thor (0.20.0)
     thread_safe (0.3.6)
@@ -344,6 +383,11 @@ GEM
     uglifier (4.0.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.4)
+      activemodel (>= 3.0.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -351,6 +395,9 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webfinger (1.1.0)
+      activesupport
+      httpclient (>= 2.4)
     webpacker (3.3.1)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -365,6 +412,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate (~> 2.7)
   bootstrap (= 4.0.0.beta2.1)
   bower-rails
   byebug
@@ -386,6 +434,7 @@ DEPENDENCIES
   letter_opener
   listen (>= 3.0.5, < 3.2)
   oj
+  omniauth_openid_connect
   paranoia
   pg (~> 0.18)
   pry

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,17 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def keycloak
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
+      set_flash_message(:notice, :success, kind: "OpenID") if is_navigational_format?
+    else
+      session['devise.keycloak_data'] = request.env.dig('omniauth.auth', 'info')
+      redirect_to new_user_registration_url
+    end
+  end
+
+  def failure
+    redirect_to root_path
+  end
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: clients
+#
+#  id              :uuid             not null, primary key
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_clients_on_organization_id_and_name  (organization_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 class Client < ApplicationRecord
   extend FriendlyId
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id         :uuid             not null, primary key
+#  name       :string           not null
+#  slug       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_organizations_on_slug  (slug) UNIQUE
+#
+
+
 class Organization < ApplicationRecord
   extend FriendlyId
 

--- a/app/models/organization_member.rb
+++ b/app/models/organization_member.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: organization_members
+#
+#  id              :bigint(8)        not null, primary key
+#  admin           :boolean          default(FALSE), not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+# Indexes
+#
+#  index_organization_members_on_organization_id_and_user_id  (organization_id,user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
+
 class OrganizationMember < ApplicationRecord
   belongs_to :organization, inverse_of: :members
   belongs_to :user, inverse_of: :organization_memberships

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: projects
+#
+#  id              :uuid             not null, primary key
+#  archived_at     :datetime
+#  budget          :integer
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  client_id       :uuid             not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_projects_on_archived_at               (archived_at)
+#  index_projects_on_organization_id_and_slug  (organization_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 class Project < ApplicationRecord
   extend FriendlyId
   include HoursAmount

--- a/app/models/project_member.rb
+++ b/app/models/project_member.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: project_members
+#
+#  id         :uuid             not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  project_id :uuid             not null
+#  user_id    :uuid             not null
+#
+# Indexes
+#
+#  index_project_members_on_user_id_and_project_id  (user_id,project_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
+
 class ProjectMember < ApplicationRecord
   belongs_to :project, inverse_of: :members
   belongs_to :user, inverse_of: :project_memberships

--- a/app/models/report_entries_export.rb
+++ b/app/models/report_entries_export.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: report_entries_exports
+#
+#  id              :uuid             not null, primary key
+#  completed_at    :datetime
+#  export_query    :json
+#  file            :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
+
 class ReportEntriesExport < ApplicationRecord
   belongs_to :organization, inverse_of: :report_entries_exports
   belongs_to :user, inverse_of: :report_entries_exports

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,5 +1,26 @@
-
 # frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: roles
+#
+#  id              :uuid             not null, primary key
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_roles_on_organization_id_and_slug  (organization_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 
 class Role < ApplicationRecord
   extend FriendlyId

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id              :uuid             not null, primary key
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 class Task < ApplicationRecord
   extend FriendlyId
 

--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: time_entries
+#
+#  id          :uuid             not null, primary key
+#  amount      :integer          not null
+#  executed_on :date             not null
+#  notes       :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  project_id  :uuid             not null
+#  task_id     :uuid             not null
+#  user_id     :uuid             not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (task_id => tasks.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
+
 class TimeEntry < ApplicationRecord
   include HoursAmount
   WEEK_ID_FORMAT = '%G-%V'

--- a/app/models/time_off_entry.rb
+++ b/app/models/time_off_entry.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: time_off_entries
+#
+#  id                 :uuid             not null, primary key
+#  amount             :integer          not null
+#  executed_on        :date             not null
+#  notes              :string
+#  status             :string           default("pending")
+#  typology           :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  organization_id    :uuid             not null
+#  time_off_period_id :uuid
+#  user_id            :uuid             not null
+#
+
 class TimeOffEntry < ApplicationRecord
   include HoursAmount
 

--- a/app/models/time_off_period.rb
+++ b/app/models/time_off_period.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: time_off_periods
+#
+#  id              :uuid             not null, primary key
+#  duration        :integer          not null
+#  end_date        :date             not null
+#  notes           :string
+#  start_date      :date             not null
+#  status          :string           default("pending")
+#  typology        :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+
+
 class TimeOffPeriod < ApplicationRecord
   belongs_to :user, inverse_of: :time_off_periods
   belongs_to :organization, inverse_of: :time_off_periods

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,7 +128,7 @@ class User < ApplicationRecord
         first_name: auth.info.first_name,
         last_name:  auth.info.last_name,
         openid_uid: auth.uid,
-      ) unless user.external_provider?
+      )
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,55 @@
 # frozen_string_literal: true
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :uuid             not null, primary key
+#  admin                  :boolean          default(FALSE), not null
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :inet
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  first_name             :string
+#  invitation_accepted_at :datetime
+#  invitation_created_at  :datetime
+#  invitation_limit       :integer
+#  invitation_sent_at     :datetime
+#  invitation_token       :string
+#  invitations_count      :integer          default(0)
+#  last_name              :string
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :inet
+#  openid_uid             :uuid
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  sign_in_count          :integer          default(0), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  invited_by_id          :uuid
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_invitation_token      (invitation_token) UNIQUE
+#  index_users_on_invitations_count     (invitations_count)
+#  index_users_on_openid_uid            (openid_uid) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (invited_by_id => users.id)
+#
 
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :invitable, :database_authenticatable, :confirmable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:keycloak]
 
   has_many :organization_memberships, class_name: 'OrganizationMember', inverse_of: :user
   has_many :organizations, through: :organization_memberships
@@ -36,6 +81,10 @@ class User < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  def external_provider?
+    openid_uid.present?
+  end
+
   def projects_in_organization organization
     projects.in_organization(organization)
   end
@@ -57,11 +106,29 @@ class User < ApplicationRecord
 
   def admin_in_organization? organization_or_id
     organization_id = organization_or_id.respond_to?(:id) ? organization_or_id.id : organization_or_id
-    membership = organization_memberships.find_by(organization_id: organization_id)
+    membership      = organization_memberships.find_by(organization_id: organization_id)
     membership&.admin?
   end
 
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
+  end
+
+  def self.from_omniauth(auth)
+    where(email: auth.info.email).first_or_create { |user|
+      user.email      = auth.info.email
+      user.password   = Devise.friendly_token[0, 20]
+      user.first_name = auth.info.first_name
+      user.last_name  = auth.info.last_name
+      user.openid_uid = auth.uid
+      user.skip_confirmation!
+    }.tap do |user|
+      user.update_attributes(
+        email:      auth.info.email,
+        first_name: auth.info.first_name,
+        last_name:  auth.info.last_name,
+        openid_uid: auth.uid,
+      ) unless user.external_provider?
+    end
   end
 end

--- a/app/models/views/this_week_time_entry.rb
+++ b/app/models/views/this_week_time_entry.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: this_week_time_entries
+#
+#  id          :uuid
+#  amount      :integer
+#  executed_on :date
+#  notes       :string
+#  created_at  :datetime
+#  updated_at  :datetime
+#  project_id  :uuid
+#  task_id     :uuid
+#  user_id     :uuid
+#
+
+
 module Views
   class ThisWeekTimeEntry < ApplicationRecord
     def readonly?

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -2,17 +2,22 @@
   .col
     h4 Your Profile
 
+- if current_user.external_provider?
+  .row
+    .col
+      .alert.alert-info= 'You are registered with an external account. Use your provider to change your information'
+
 .row
   .col
     = form_for resource, as: resource_name, url: registration_path(resource_name), html: { method: :put } do |f|
       .form-group.row
         = f.label :first_name, class: 'col-sm-2 col-form-label'
         .col-sm-4
-          = f.text_field :first_name, class: 'form-control'
+          = f.text_field :first_name, class: 'form-control', disabled: current_user.external_provider?
           small.form-text.text-danger= f.object.errors[:first_name].join ', '
         = f.label :last_name, class: 'col-sm-2 col-form-label'
         .col-sm-4
-          = f.text_field :last_name, class: 'form-control'
+          = f.text_field :last_name, class: 'form-control', disabled: current_user.external_provider?
           small.form-text.text-danger= f.object.errors[:last_name].join ', '
 
       .form-group.row
@@ -24,13 +29,13 @@
             - if !current_user.email_changed? && f.object.unconfirmed_email
               small.form-text.text-muted= "This email is pending confirmation. Until then, the old email (#{f.object.email}) will be used."
           - else
-            = f.email_field :email, class: 'form-control'
+            = f.email_field :email, class: 'form-control', disabled: current_user.external_provider?
           small.form-text.text-danger= f.object.errors[:email].join ', '
 
       .form-group.row
         = f.label :password, class: 'col-sm-2 col-form-label'
         .col-sm-10
-          = f.password_field :password, autocomplete: 'off', class: 'form-control'
+          = f.password_field :password, autocomplete: 'off', class: 'form-control', disabled: current_user.external_provider?
           small.form-text.text-muted
             | leave blank if you don't want to change it.
             - if @minimum_password_length
@@ -39,17 +44,17 @@
       .form-group.row
         = f.label :password_confirmation, class: 'col-sm-2 col-form-label'
         .col-sm-10
-          = f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control'
+          = f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control', disabled: current_user.external_provider?
 
       .form-group.row
         = f.label :current_password, class: 'col-sm-2 col-form-label'
         .col-sm-10
-          = f.password_field :current_password, autocomplete: 'off', class: 'form-control'
+          = f.password_field :current_password, autocomplete: 'off', class: 'form-control', disabled: current_user.external_provider?
           small.form-text.text-muted we need your current password to confirm your changes.
 
       .row.justify-content-end
         .col-sm-10
-          = f.submit class: 'btn btn-primary'
+          = f.submit class: 'btn btn-primary', disabled: current_user.external_provider?
           = link_to 'Cancel my account', registration_path(resource_name), \
                     data: { confirm: 'Are you sure?' }, method: :delete, \
-                    class: 'btn btn-danger ml-2'
+                    class: 'btn btn-danger ml-2' unless current_user.external_provider?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -7,3 +7,4 @@
       p.lead
         = link_to 'Sign in', new_user_session_path, class: 'btn btn-primary btn-lg'
         = link_to 'Sign up', new_user_registration_path, class: 'btn btn-primary btn-lg ml-2'
+        = link_to 'Sign in with your Mikamai account', user_keycloak_omniauth_authorize_path, class: 'btn btn-primary btn-lg ml-2'

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,8 +2,12 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV['POSTGRES_USER'] %>
-  password: <%= ENV['POSTGRES_PASS'] %>
+#  host: <%= ENV['POSTGRES_HOST'] %>
+  host: localhost
+#  username: <%= ENV['POSTGRES_USER'] %>
+#  password: <%= ENV['POSTGRES_PASS'] %>
+  username: timetable
+  password: timetable
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,12 +2,9 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-#  host: <%= ENV['POSTGRES_HOST'] %>
-  host: localhost
-#  username: <%= ENV['POSTGRES_USER'] %>
-#  password: <%= ENV['POSTGRES_PASS'] %>
-  username: timetable
-  password: timetable
+  host: <%= ENV['POSTGRES_HOST'] %>
+  username: <%= ENV['POSTGRES_USER'] %>
+  password: <%= ENV['POSTGRES_PASS'] %>
 
 development:
   <<: *default

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -304,6 +304,26 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
+  issuer     = ENV.fetch('OP_ISSUER', 'http://localhost')
+  issuer_uri = URI(issuer)
+
+  config.omniauth :openid_connect, {
+    name:           :keycloak,
+    scope:          %i[openid email profile],
+    response_type:  :code,
+    discovery:      true,
+    issuer:         issuer,
+    uid_field:      'preferred_username',
+    client_options: {
+      port:         issuer_uri.port,
+      scheme:       issuer_uri.scheme,
+      host:         issuer_uri.host,
+      identifier:   ENV['OP_CLIENT_ID'],
+      secret:       ENV['OP_SECRET_KEY'],
+      redirect_uri: "#{Rails.env.production? ? 'https' : 'http'}://#{Rails.application.secrets.web_domain}/users/auth/keycloak/callback"
+    },
+  }
+
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -304,7 +304,7 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
-  issuer     = ENV.fetch('OP_ISSUER', 'http://localhost')
+  issuer     = ENV['OP_ISSUER']
   issuer_uri = URI(issuer)
 
   config.omniauth :openid_connect, {

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -304,25 +304,27 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
-  issuer     = ENV['OP_ISSUER']
-  issuer_uri = URI(issuer)
+  issuer = ENV['OP_ISSUER']
+  if issuer.present?
+    issuer_uri = URI(issuer)
 
-  config.omniauth :openid_connect, {
-    name:           :keycloak,
-    scope:          %i[openid email profile],
-    response_type:  :code,
-    discovery:      true,
-    issuer:         issuer,
-    uid_field:      'preferred_username',
-    client_options: {
-      port:         issuer_uri.port,
-      scheme:       issuer_uri.scheme,
-      host:         issuer_uri.host,
-      identifier:   ENV['OP_CLIENT_ID'],
-      secret:       ENV['OP_SECRET_KEY'],
-      redirect_uri: "#{Rails.env.production? ? 'https' : 'http'}://#{Rails.application.secrets.web_domain}/users/auth/keycloak/callback"
-    },
-  }
+    config.omniauth :openid_connect, {
+      name:           :keycloak,
+      scope:          %i[openid email profile],
+      response_type:  :code,
+      discovery:      true,
+      issuer:         issuer,
+      uid_field:      'preferred_username',
+      client_options: {
+        port:         issuer_uri.port,
+        scheme:       issuer_uri.scheme,
+        host:         issuer_uri.host,
+        identifier:   ENV['OP_CLIENT_ID'],
+        secret:       ENV['OP_SECRET_KEY'],
+        redirect_uri: "#{Rails.env.production? ? 'https' : 'http'}://#{Rails.application.secrets.web_domain}/users/auth/keycloak/callback"
+      },
+    }
+  end
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@
 
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    invitations: 'users/invitations'
+    invitations: 'users/invitations',
+    omniauth_callbacks: 'users/omniauth_callbacks'
   }
 
   namespace :admin do

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,5 +1,5 @@
 default: &default
-  web_domain: <%= ENV.fetch 'WEB_DOMAIN', 'localhost:3000' %>
+  web_domain: <%= ENV.fetch 'WEB_DOMAIN', 'localhost:5000' %>
   mail_from: <%= ENV.fetch 'MAIL_FROM', 'timetable@mikamai.com' %>
 
 development:

--- a/db/migrate/20190301204206_add_keycloak_to_user.rb
+++ b/db/migrate/20190301204206_add_keycloak_to_user.rb
@@ -1,0 +1,6 @@
+class AddKeycloakToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :openid_uid, :uuid, null: true
+    add_index :users, :openid_uid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181205105327) do
+ActiveRecord::Schema.define(version: 20190301204206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -176,9 +176,11 @@ ActiveRecord::Schema.define(version: 20181205105327) do
     t.integer "invitation_limit"
     t.uuid "invited_by_id"
     t.integer "invitations_count", default: 0
+    t.uuid "openid_uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
+    t.index ["openid_uid"], name: "index_users_on_openid_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.1'
+
+services:
+  postgres:
+    image: postgres:10.5-alpine
+    ports:
+    - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: timetable
+      POSTGRES_USER: timetable
+      POSTGRES_DB: timetable_development
+    volumes:
+    - "timetable_db:/var/lib/postgresql/data"
+  keycloak_server:
+    image: jboss/keycloak:4.8.3.Final
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+      DB_VENDOR: postgres
+      DB_ADDR: database
+    ports:
+      - "80:8080"
+    links:
+      - database
+  database:
+    image: postgres:10.5-alpine
+    volumes:
+      - "keycloak_db:/var/lib/postgresql/data"
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: keycloak
+      POSTGRES_DB: keycloak
+volumes:
+  timetable_db:
+  keycloak_db:

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,54 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'routes'                    => 'false',
+      'position_in_routes'        => 'before',
+      'position_in_class'         => 'before',
+      'position_in_test'          => 'before',
+      'position_in_fixture'       => 'before',
+      'position_in_factory'       => 'before',
+      'position_in_serializer'    => 'before',
+      'show_foreign_keys'         => 'true',
+      'show_complete_foreign_keys' => 'false',
+      'show_indexes'              => 'true',
+      'simple_indexes'            => 'false',
+      'model_dir'                 => 'app/models',
+      'root_dir'                  => '',
+      'include_version'           => 'false',
+      'require'                   => '',
+      'exclude_tests'             => 'false',
+      'exclude_fixtures'          => 'false',
+      'exclude_factories'         => 'false',
+      'exclude_serializers'       => 'false',
+      'exclude_scaffolds'         => 'true',
+      'exclude_controllers'       => 'true',
+      'exclude_helpers'           => 'true',
+      'exclude_sti_subclasses'    => 'false',
+      'ignore_model_sub_dir'      => 'false',
+      'ignore_columns'            => nil,
+      'ignore_routes'             => nil,
+      'ignore_unknown_models'     => 'false',
+      'hide_limit_column_types'   => 'integer,boolean',
+      'hide_default_column_types' => 'json,jsonb,hstore',
+      'skip_on_db_migrate'        => 'false',
+      'format_bare'               => 'true',
+      'format_rdoc'               => 'false',
+      'format_markdown'           => 'false',
+      'sort'                      => 'false',
+      'force'                     => 'false',
+      'classified_sort'           => 'true',
+      'trace'                     => 'false',
+      'wrapper_open'              => nil,
+      'wrapper_close'             => nil,
+      'with_comment'              => true
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: clients
+#
+#  id              :uuid             not null, primary key
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_clients_on_organization_id_and_name  (organization_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 FactoryBot.define do
   sequence(:client_name) { |n| "Client #{n}" }
 

--- a/spec/factories/organization_members.rb
+++ b/spec/factories/organization_members.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: organization_members
+#
+#  id              :bigint(8)        not null, primary key
+#  admin           :boolean          default(FALSE), not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+# Indexes
+#
+#  index_organization_members_on_organization_id_and_user_id  (organization_id,user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
+
 FactoryBot.define do
   factory :organization_member do
     user

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id         :uuid             not null, primary key
+#  name       :string           not null
+#  slug       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_organizations_on_slug  (slug) UNIQUE
+#
+
+
 FactoryBot.define do
   sequence(:organization_name) { |n| "Organization #{n}" }
 

--- a/spec/factories/project_members.rb
+++ b/spec/factories/project_members.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: project_members
+#
+#  id         :uuid             not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  project_id :uuid             not null
+#  user_id    :uuid             not null
+#
+# Indexes
+#
+#  index_project_members_on_user_id_and_project_id  (user_id,project_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
+
 FactoryBot.define do
   factory :project_member do
     project

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: projects
+#
+#  id              :uuid             not null, primary key
+#  archived_at     :datetime
+#  budget          :integer
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  client_id       :uuid             not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_projects_on_archived_at               (archived_at)
+#  index_projects_on_organization_id_and_slug  (organization_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 FactoryBot.define do
   sequence(:project_name) { |n| "Project #{n}" }
 

--- a/spec/factories/report_entries_exports.rb
+++ b/spec/factories/report_entries_exports.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: report_entries_exports
+#
+#  id              :uuid             not null, primary key
+#  completed_at    :datetime
+#  export_query    :json
+#  file            :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
 FactoryBot.define do
   factory :report_entries_export do
     organization

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: roles
+#
+#  id              :uuid             not null, primary key
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_roles_on_organization_id_and_slug  (organization_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 FactoryBot.define do
   sequence(:role_name) { |n| "role #{n}" }
 

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id              :uuid             not null, primary key
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 FactoryBot.define do
   sequence(:task_name) { |n| "Task #{n}" }
 

--- a/spec/factories/time_entries.rb
+++ b/spec/factories/time_entries.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: time_entries
+#
+#  id          :uuid             not null, primary key
+#  amount      :integer          not null
+#  executed_on :date             not null
+#  notes       :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  project_id  :uuid             not null
+#  task_id     :uuid             not null
+#  user_id     :uuid             not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (task_id => tasks.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
+
 FactoryBot.define do
   factory :time_entry do
     transient do

--- a/spec/factories/time_off_entries.rb
+++ b/spec/factories/time_off_entries.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: time_off_entries
+#
+#  id                 :uuid             not null, primary key
+#  amount             :integer          not null
+#  executed_on        :date             not null
+#  notes              :string
+#  status             :string           default("pending")
+#  typology           :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  organization_id    :uuid             not null
+#  time_off_period_id :uuid
+#  user_id            :uuid             not null
+#
+
 FactoryBot.define do
   factory :time_off_entry do
     transient do

--- a/spec/factories/time_off_periods.rb
+++ b/spec/factories/time_off_periods.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: time_off_periods
+#
+#  id              :uuid             not null, primary key
+#  duration        :integer          not null
+#  end_date        :date             not null
+#  notes           :string
+#  start_date      :date             not null
+#  status          :string           default("pending")
+#  typology        :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+
 FactoryBot.define do
   factory :time_off_period do
     transient do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,49 @@
 # frozen_string_literal: true
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :uuid             not null, primary key
+#  admin                  :boolean          default(FALSE), not null
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :inet
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  first_name             :string
+#  invitation_accepted_at :datetime
+#  invitation_created_at  :datetime
+#  invitation_limit       :integer
+#  invitation_sent_at     :datetime
+#  invitation_token       :string
+#  invitations_count      :integer          default(0)
+#  last_name              :string
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :inet
+#  openid_uid             :uuid
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  sign_in_count          :integer          default(0), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  invited_by_id          :uuid
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_invitation_token      (invitation_token) UNIQUE
+#  index_users_on_invitations_count     (invitations_count)
+#  index_users_on_openid_uid            (openid_uid) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (invited_by_id => users.id)
+#
 
 FactoryBot.define do
   sequence(:user_email) { |n| "user_#{n}@mikamai.com" }

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: clients
+#
+#  id              :uuid             not null, primary key
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_clients_on_organization_id_and_name  (organization_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 require 'rails_helper'
 
 RSpec.describe Client, type: :model do

--- a/spec/models/organization_member_spec.rb
+++ b/spec/models/organization_member_spec.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: organization_members
+#
+#  id              :bigint(8)        not null, primary key
+#  admin           :boolean          default(FALSE), not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+# Indexes
+#
+#  index_organization_members_on_organization_id_and_user_id  (organization_id,user_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
+
 require 'rails_helper'
 
 RSpec.describe OrganizationMember, type: :model do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id         :uuid             not null, primary key
+#  name       :string           not null
+#  slug       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_organizations_on_slug  (slug) UNIQUE
+#
+
+
 require 'rails_helper'
 
 RSpec.describe Organization, type: :model do

--- a/spec/models/project_member_spec.rb
+++ b/spec/models/project_member_spec.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: project_members
+#
+#  id         :uuid             not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  project_id :uuid             not null
+#  user_id    :uuid             not null
+#
+# Indexes
+#
+#  index_project_members_on_user_id_and_project_id  (user_id,project_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
+
 require 'rails_helper'
 
 RSpec.describe ProjectMember, type: :model do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: projects
+#
+#  id              :uuid             not null, primary key
+#  archived_at     :datetime
+#  budget          :integer
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  client_id       :uuid             not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_projects_on_archived_at               (archived_at)
+#  index_projects_on_organization_id_and_slug  (organization_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (client_id => clients.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 require 'rails_helper'
 
 RSpec.describe Project, type: :model do

--- a/spec/models/report_entries_export_spec.rb
+++ b/spec/models/report_entries_export_spec.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: report_entries_exports
+#
+#  id              :uuid             not null, primary key
+#  completed_at    :datetime
+#  export_query    :json
+#  file            :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
 require 'rails_helper'
 
 RSpec.describe ReportEntriesExport, type: :model do

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: roles
+#
+#  id              :uuid             not null, primary key
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_roles_on_organization_id_and_slug  (organization_id,slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 require 'rails_helper'
 
 RSpec.describe Role, type: :model do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id              :uuid             not null, primary key
+#  name            :string           not null
+#  slug            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+
+
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do

--- a/spec/models/time_entry_spec.rb
+++ b/spec/models/time_entry_spec.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: time_entries
+#
+#  id          :uuid             not null, primary key
+#  amount      :integer          not null
+#  executed_on :date             not null
+#  notes       :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  project_id  :uuid             not null
+#  task_id     :uuid             not null
+#  user_id     :uuid             not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (task_id => tasks.id)
+#  fk_rails_...  (user_id => users.id)
+#
+
+
 require 'rails_helper'
 
 RSpec.describe TimeEntry, type: :model do

--- a/spec/models/time_off_entry_spec.rb
+++ b/spec/models/time_off_entry_spec.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: time_off_entries
+#
+#  id                 :uuid             not null, primary key
+#  amount             :integer          not null
+#  executed_on        :date             not null
+#  notes              :string
+#  status             :string           default("pending")
+#  typology           :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  organization_id    :uuid             not null
+#  time_off_period_id :uuid
+#  user_id            :uuid             not null
+#
+
+
 require 'rails_helper'
 
 RSpec.describe TimeOffEntry, type: :model do

--- a/spec/models/time_off_period_spec.rb
+++ b/spec/models/time_off_period_spec.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: time_off_periods
+#
+#  id              :uuid             not null, primary key
+#  duration        :integer          not null
+#  end_date        :date             not null
+#  notes           :string
+#  start_date      :date             not null
+#  status          :string           default("pending")
+#  typology        :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+
 require 'rails_helper'
 
 RSpec.describe TimeOffPeriod, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -163,5 +163,22 @@ RSpec.describe User, type: :model do
              executed_on: Date.today.end_of_week + 1.day, amount: 2401
       expect(subject.without_enough_entries_this_week).to eq [pm.user]
     end
+
+  end
+
+  describe 'omniauth' do
+    subject { create :user }
+    let(:info) { double email: subject.email, first_name: 'openid', last_name: 'openid' }
+    let(:auth) { double uid: SecureRandom.uuid, info: info }
+
+    it 'updates the user if logged in via OpenID' do
+      user = User.from_omniauth(auth)
+      subject.reload
+      expect(subject.email).to eq user.email
+      expect(subject.first_name).to eq 'openid'
+      expect(subject.last_name).to eq 'openid'
+      expect(subject.openid_uid).to eq auth.uid
+    end
+
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,49 @@
 # frozen_string_literal: true
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :uuid             not null, primary key
+#  admin                  :boolean          default(FALSE), not null
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :inet
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  first_name             :string
+#  invitation_accepted_at :datetime
+#  invitation_created_at  :datetime
+#  invitation_limit       :integer
+#  invitation_sent_at     :datetime
+#  invitation_token       :string
+#  invitations_count      :integer          default(0)
+#  last_name              :string
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :inet
+#  openid_uid             :uuid
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  sign_in_count          :integer          default(0), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  invited_by_id          :uuid
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_invitation_token      (invitation_token) UNIQUE
+#  index_users_on_invitations_count     (invitations_count)
+#  index_users_on_openid_uid            (openid_uid) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (invited_by_id => users.id)
+#
 
 require 'rails_helper'
 

--- a/spec/models/views/this_week_time_entry_spec.rb
+++ b/spec/models/views/this_week_time_entry_spec.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: this_week_time_entries
+#
+#  id          :uuid
+#  amount      :integer
+#  executed_on :date
+#  notes       :string
+#  created_at  :datetime
+#  updated_at  :datetime
+#  project_id  :uuid
+#  task_id     :uuid
+#  user_id     :uuid
+#
+
+
 require 'rails_helper'
 
 RSpec.describe Views::ThisWeekTimeEntry, type: :model do


### PR DESCRIPTION
Added login via Omniauth OpenID Connect to support using Mikamai SSO.
Configure using environment variables:
- `OP_ISSUER` -> `https://sso.mikamai.com/auth/realms/mikamai`
- `OP_CLIENT_ID` -> `timetable`
- `OP_SECRET_KEY` -> `value-from-sso`

Users already registered on Timetable can transition their accounts if they have the same email address.
If logging in via Mikamai SSO and an existing user is found, all personal information (first and last name) is overridden with the values from the SSO. Everything else is kept as-is. Even the old password is still working.

On the other hand, if the user is a new user, she will not be able to log in with the regular password, as none has been set.